### PR TITLE
Use ==/!= to compare constant literals (str, bytes, int, float, tuple)

### DIFF
--- a/matchingmarkets/algorithms/pulp/pulp.py
+++ b/matchingmarkets/algorithms/pulp/pulp.py
@@ -698,8 +698,7 @@ class LpAffineExpression(_DICT_TYPE):
         return result
 
     def addInPlace(self, other):
-        if other is 0: return self
-        if other is None: return self
+        if other in (0, None): return self
         if isinstance(other,LpElement):
             self.addterm(other, 1)
         elif isinstance(other,LpAffineExpression):
@@ -718,8 +717,7 @@ class LpAffineExpression(_DICT_TYPE):
         return self
 
     def subInPlace(self, other):
-        if other is 0: return self
-        if other is None: return self
+        if other in (0, None): return self
         if isinstance(other,LpElement):
             self.addterm(other, -1)
         elif isinstance(other,LpAffineExpression):


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> 0 is 0
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```